### PR TITLE
Add Alternative Initialization Method for Repositories with Submodules

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@
 git clone --recursive https://github.com/jnjaby/KEEP
 cd KEEP
 
+# alternatively
+git clone https://github.com/jnjaby/KEEP
+cd KEEP
+git submodule init
+git submodule update
+
 # create new anaconda env
 conda create -n keep python=3.8 -y
 conda activate keep


### PR DESCRIPTION
Changes Introduced

- Added documentation on initializing submodules manually using:
  - git submodule init
  - git submodule update
- Updated README.md to include instructions for developers who may have forgotten to clone with --recursive.